### PR TITLE
Producing to kafka

### DIFF
--- a/producer/ContentProducer.go
+++ b/producer/ContentProducer.go
@@ -1,0 +1,116 @@
+package producer
+
+import (
+	"errors"
+	"github.com/Financial-Times/message-queue-go-producer/producer"
+	"github.com/Financial-Times/uuid-utils-go"
+	gouuid "github.com/satori/go.uuid"
+	log "github.com/Sirupsen/logrus"
+	"encoding/json"
+)
+
+const (
+	uriBase             = "http://content-collection-unfolder.svc.ft.com/content/"
+	cmsContentPublished = "cms-content-published"
+	methodeSystemOrigin = "http://cmdb.ft.com/systems/methode-web-pub"
+
+	//time format (also not needed atm)
+	//timeFormat = "2006-01-02T03:04:05.000Z0700"
+
+	//mapper uri bases (not needed)
+	//articleUriBase = "http://methode-article-mapper.svc.ft.com/content/"
+	//placeholderUriBase = "http://methode-content-placeholder-mapper-iw-uk-p.svc.ft.com/content/"
+	//videoUriBase = "http://next-video-mapper.svc.ft.com/video/model/"
+
+)
+
+type ContentProducer struct {
+	msgProducer producer.MessageProducer
+}
+
+func (p ContentProducer) Send(tid string, lastModified string, contentArr []map[string]interface{}) {
+	for _, content := range contentArr {
+		p.sendSingleMessage(tid, content, lastModified)
+	}
+}
+func (p ContentProducer) sendSingleMessage(tid string, content map[string]interface{}, lastModified string) {
+	logEntry := log.WithField("tid", tid)
+	uuid, err := p.extractUuid(content)
+	if nil != nil {
+		logEntry.Warnf("Skip creation of kafka message. Reason: %v ", err)
+	}
+
+	logEntry = logEntry.WithField("uuid", uuid)
+	msg, err := p.buildMessage(tid, uuid, lastModified, content)
+	if err != nil {
+		logEntry.Warnf("Skip creation of kafka message. Reason: %v ", err)
+	}
+
+	err = p.msgProducer.SendMessage("", msg)
+	if err != nil {
+		logEntry.Warnf("Unable to send message to Kafka. Reason: %v ", err)
+	}
+}
+
+func (p ContentProducer) extractUuid(content map[string]interface{}) (string, error) {
+	val, ok := content["uuid"]
+	if !ok {
+		return "", errors.New("No UUID found in content")
+	}
+
+	uuid, ok := val.(string)
+	if !ok {
+		return "", errors.New("Found UUID was not a string")
+	}
+
+	err := uuidutils.ValidateUUID(uuid)
+	if err != nil {
+		return "", err
+	}
+
+	return uuid, nil
+}
+
+func (p ContentProducer) buildMessage(tid string, uuid string, lastModified string, content map[string]interface{}) (producer.Message, error) {
+	body := publicationMessageBody{
+		ContentURI:   uriBase + uuid,
+		LastModified: lastModified,
+		Payload:      content,
+	}
+	bodyAsString, err := p.marshallToString(&body)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := map[string]string{
+		"X-Request-Id":      tid,
+		"Message-Timestamp": lastModified,
+		"Message-Id":        gouuid.NewV4().String(),
+		"Message-Type":      cmsContentPublished,
+		"Origin-System-Id":  methodeSystemOrigin,
+		"Content-Type":      "application/json",
+	}
+
+	return producer.Message{Headers: headers, Body: *bodyAsString}, nil
+
+}
+
+func (p ContentProducer) marshallToString(body *publicationMessageBody) (*string, error) {
+	binary, err := json.Marshal(*body)
+	if err != nil {
+		return nil, err
+	}
+
+	//not sure if needed
+	//binary = bytes.Replace(binary, []byte("\\u003c"), []byte("<"), -1)
+	//binary = bytes.Replace(binary, []byte("\\u003e"), []byte(">"), -1)
+
+	return &string(binary), nil
+}
+
+type publicationMessageBody struct {
+	ContentURI   string                 `json:"contentUri"`
+	LastModified string                 `json:"lastModified"`
+	Payload      map[string]interface{} `json:"payload"`
+}
+

--- a/producer/ContentProducer.go
+++ b/producer/ContentProducer.go
@@ -1,12 +1,12 @@
 package producer
 
 import (
+	"encoding/json"
 	"errors"
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	"github.com/Financial-Times/uuid-utils-go"
-	gouuid "github.com/satori/go.uuid"
 	log "github.com/Sirupsen/logrus"
-	"encoding/json"
+	gouuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -36,7 +36,7 @@ func (p ContentProducer) Send(tid string, lastModified string, contentArr []map[
 func (p ContentProducer) sendSingleMessage(tid string, content map[string]interface{}, lastModified string) {
 	logEntry := log.WithField("tid", tid)
 	uuid, err := p.extractUuid(content)
-	if nil != nil {
+	if err != nil {
 		logEntry.Warnf("Skip creation of kafka message. Reason: %v ", err)
 	}
 
@@ -113,4 +113,3 @@ type publicationMessageBody struct {
 	LastModified string                 `json:"lastModified"`
 	Payload      map[string]interface{} `json:"payload"`
 }
-

--- a/producer/contentProducer.go
+++ b/producer/contentProducer.go
@@ -13,12 +13,6 @@ const (
 	uriBase             = "http://content-collection-unfolder.svc.ft.com/content/"
 	cmsContentPublished = "cms-content-published"
 	methodeSystemOrigin = "http://cmdb.ft.com/systems/methode-web-pub"
-
-	//mapper uri bases (not needed)
-	//articleUriBase = "http://methode-article-mapper.svc.ft.com/content/"
-	//placeholderUriBase = "http://methode-content-placeholder-mapper-iw-uk-p.svc.ft.com/content/"
-	//videoUriBase = "http://next-video-mapper.svc.ft.com/video/model/"
-
 )
 
 type ContentProducer struct {

--- a/producer/contentProducer_test.go
+++ b/producer/contentProducer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Financial-Times/uuid-utils-go"
 	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	_ "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"testing"
 	"time"

--- a/producer/contentProducer_test.go
+++ b/producer/contentProducer_test.go
@@ -2,6 +2,7 @@ package producer
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/Financial-Times/message-queue-go-producer/producer"
 	tidutils "github.com/Financial-Times/transactionid-utils-go"
 	"github.com/Financial-Times/uuid-utils-go"
@@ -11,7 +12,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"testing"
 	"time"
-	"errors"
 )
 
 const timeFormat = "2006-01-02T03:04:05.000Z0700"
@@ -86,7 +86,7 @@ func TestFailedUuidExtractionCausesSkip(t *testing.T) {
 
 	cp.Send(tidutils.NewTransactionID(),
 		time.Now().Format(timeFormat),
-		[]map[string]interface{} {{}, {"uuid" : 123}, {"uuid" : "1234"}})
+		[]map[string]interface{}{{}, {"uuid": 123}, {"uuid": "1234"}})
 
 	mp.AssertNotCalled(t, "SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message"))
 }
@@ -115,7 +115,7 @@ func TestMarshallErrorsCauseSkip(t *testing.T) {
 
 	cp.Send(tidutils.NewTransactionID(),
 		time.Now().Format(timeFormat),
-		[]map[string]interface{} {{"uuid" : gouuid.NewV4().String(), "dude, what?" : func() {}}})
+		[]map[string]interface{}{{"uuid": gouuid.NewV4().String(), "dude, what?": func() {}}})
 
 	mp.AssertNotCalled(t, "SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message"))
 }

--- a/producer/contentProducer_test.go
+++ b/producer/contentProducer_test.go
@@ -1,0 +1,141 @@
+package producer
+
+import (
+	"encoding/json"
+	"github.com/Financial-Times/message-queue-go-producer/producer"
+	tidutils "github.com/Financial-Times/transactionid-utils-go"
+	"github.com/Financial-Times/uuid-utils-go"
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	_ "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
+	"errors"
+)
+
+const timeFormat = "2006-01-02T03:04:05.000Z0700"
+
+func TestHeadersAndBodyAreOk(t *testing.T) {
+	mp := new(MockProducer)
+	mp.On("SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message")).Return(nil)
+
+	cp := ContentProducer{mp}
+
+	tid := tidutils.NewTransactionID()
+	lastModified := time.Now().Format(timeFormat)
+	uuid := gouuid.NewV4().String()
+	contentArr := map[string]interface{}{"uuid": uuid}
+
+	cp.Send(tid, lastModified, []map[string]interface{}{contentArr})
+
+	mp.AssertCalled(t, "SendMessage",
+		mock.MatchedBy(func(key string) bool {
+			assert.Equal(t, "", key)
+			return true
+		}),
+		mock.MatchedBy(func(msg producer.Message) bool {
+			//validate headers
+			assert.Equal(t, tid, msg.Headers["X-Request-Id"])
+			assert.Equal(t, lastModified, msg.Headers["Message-Timestamp"])
+			assert.Equal(t, cmsContentPublished, msg.Headers["Message-Type"])
+			assert.Equal(t, methodeSystemOrigin, msg.Headers["Origin-System-Id"])
+			assert.Equal(t, "application/json", msg.Headers["Content-Type"])
+			assert.NoError(t, uuidutils.ValidateUUID(msg.Headers["Message-Id"]))
+
+			//validate body
+			body := unmarshall(msg.Body)
+			assert.Equal(t, uriBase+uuid, body["contentUri"].(string))
+			assert.Equal(t, lastModified, body["lastModified"])
+			assert.Equal(t, contentArr, body["payload"])
+
+			return true
+		}),
+	)
+	mp.AssertNumberOfCalls(t, "SendMessage", 1)
+}
+
+func TestMultipleMessagesHaveDifferentIds(t *testing.T) {
+	headerIds := []string{}
+
+	mp := new(MockProducer)
+	mp.On("SendMessage",
+		mock.AnythingOfType("string"),
+		mock.MatchedBy(func(msg producer.Message) bool {
+			headerIds = append(headerIds, msg.Headers["Message-Id"])
+			return true
+		}),
+	).Times(2).Return(nil)
+
+	cp := ContentProducer{mp}
+
+	cp.Send(tidutils.NewTransactionID(),
+		time.Now().Format(timeFormat),
+		[]map[string]interface{}{{"uuid": gouuid.NewV4().String()}, {"uuid": gouuid.NewV4().String()}})
+
+	mp.AssertNumberOfCalls(t, "SendMessage", 2)
+
+	assert.Equal(t, 2, len(headerIds))
+	assert.NotEqual(t, headerIds[0], headerIds[1])
+}
+
+func TestFailedUuidExtractionCausesSkip(t *testing.T) {
+	mp := new(MockProducer)
+
+	cp := ContentProducer{mp}
+
+	cp.Send(tidutils.NewTransactionID(),
+		time.Now().Format(timeFormat),
+		[]map[string]interface{} {{}, {"uuid" : 123}, {"uuid" : "1234"}})
+
+	mp.AssertNotCalled(t, "SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message"))
+}
+
+func TestSendFailureDoesNotStopProducer(t *testing.T) {
+	mp := new(MockProducer)
+	mp.On("SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message")).Times(4).Return(errors.New("Test error"))
+
+	cp := ContentProducer{mp}
+
+	contentArr := []map[string]interface{}{{"uuid": gouuid.NewV4().String()}, {"uuid": gouuid.NewV4().String()}}
+	cp.Send(tidutils.NewTransactionID(),
+		time.Now().Format(timeFormat),
+		contentArr)
+	cp.Send(tidutils.NewTransactionID(),
+		time.Now().Format(timeFormat),
+		contentArr)
+
+	mp.AssertNumberOfCalls(t, "SendMessage", 4)
+}
+
+func TestMarshallErrorsCauseSkip(t *testing.T) {
+	mp := new(MockProducer)
+
+	cp := ContentProducer{mp}
+
+	cp.Send(tidutils.NewTransactionID(),
+		time.Now().Format(timeFormat),
+		[]map[string]interface{} {{"uuid" : gouuid.NewV4().String(), "dude, what?" : func() {}}})
+
+	mp.AssertNotCalled(t, "SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message"))
+}
+
+func unmarshall(jsonString string) map[string]interface{} {
+	var u map[string]interface{}
+	json.Unmarshal([]byte(jsonString), &u)
+	return u
+}
+
+type MockProducer struct {
+	mock.Mock
+}
+
+func (mp *MockProducer) SendMessage(key string, msg producer.Message) error {
+	args := mp.Called(key, msg)
+	return args.Error(0)
+}
+
+func (mp *MockProducer) ConnectivityCheck() (string, error) {
+	args := mp.Called()
+	return args.String(0), args.Error(1)
+}

--- a/producer/contentProducer_test.go
+++ b/producer/contentProducer_test.go
@@ -19,7 +19,7 @@ func TestHeadersAndBodyAreOk(t *testing.T) {
 	mp := new(MockProducer)
 	mp.On("SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message")).Return(nil)
 
-	cp := ContentProducer{mp}
+	cp := NewContentProducer(mp)
 
 	tid := tidutils.NewTransactionID()
 	lastModified := time.Now().Format(timeFormat)
@@ -66,7 +66,7 @@ func TestMultipleMessagesHaveDifferentIds(t *testing.T) {
 		}),
 	).Times(2).Return(nil)
 
-	cp := ContentProducer{mp}
+	cp := NewContentProducer(mp)
 
 	cp.Send(tidutils.NewTransactionID(),
 		time.Now().Format(timeFormat),
@@ -81,7 +81,7 @@ func TestMultipleMessagesHaveDifferentIds(t *testing.T) {
 func TestFailedUuidExtractionCausesSkip(t *testing.T) {
 	mp := new(MockProducer)
 
-	cp := ContentProducer{mp}
+	cp := NewContentProducer(mp)
 
 	cp.Send(tidutils.NewTransactionID(),
 		time.Now().Format(timeFormat),
@@ -94,7 +94,7 @@ func TestSendFailureDoesNotStopProducer(t *testing.T) {
 	mp := new(MockProducer)
 	mp.On("SendMessage", mock.AnythingOfType("string"), mock.AnythingOfType("producer.Message")).Times(4).Return(errors.New("Test error"))
 
-	cp := ContentProducer{mp}
+	cp := NewContentProducer(mp)
 
 	contentArr := []map[string]interface{}{{"uuid": gouuid.NewV4().String()}, {"uuid": gouuid.NewV4().String()}}
 	cp.Send(tidutils.NewTransactionID(),
@@ -110,7 +110,7 @@ func TestSendFailureDoesNotStopProducer(t *testing.T) {
 func TestMarshallErrorsCauseSkip(t *testing.T) {
 	mp := new(MockProducer)
 
-	cp := ContentProducer{mp}
+	cp := NewContentProducer(mp)
 
 	cp.Send(tidutils.NewTransactionID(),
 		time.Now().Format(timeFormat),


### PR DESCRIPTION
These are the URIs used by the mappers of the content types which we are unfolding. I'm going to leave them here, just in case, because I spent quite some time digging around for them:

```
	//articleUriBase = "http://methode-article-mapper.svc.ft.com/content/"
	//placeholderUriBase = "http://methode-content-placeholder-mapper-iw-uk-p.svc.ft.com/content/"
	//videoUriBase = "http://next-video-mapper.svc.ft.com/video/model/"
```