### PR TITLE
Migrate to snuyk and orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,56 +1,19 @@
-version: 2
-jobs:
-  build:
-    working_directory: /content-collection-unfolder
-    docker:
-      - image: golang:1
-    environment:
-      GOPATH: /go
-      CIRCLE_TEST_REPORTS: /tmp/test-results
-      CIRCLE_COVERAGE_REPORT: /tmp/coverage-results
-    steps:
-      - checkout
-      - run:
-          name: External Dependencies
-          command: |
-            GO111MODULE=off go get github.com/mattn/goveralls
-            GO111MODULE=off go get github.com/jstemmer/go-junit-report
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
-            wget https://raw.githubusercontent.com/Financial-Times/upp-coding-standard/v1.0.0/golangci-config/.golangci.yml      
-      - run:
-          name: Create Test Folders
-          command: |
-            mkdir -p $CIRCLE_TEST_REPORTS
-            mkdir -p $CIRCLE_COVERAGE_REPORT
-      - run:
-          name: Go Build
-          command: go build -mod=readonly -v
-      - run:
-          name: Run linters
-          command: golangci-lint run --new-from-rev=$(git rev-parse origin/master) --config .golangci.yml
-      - run:
-          name: Run Tests
-          command: go test -mod=readonly -race -cover -coverprofile=${CIRCLE_COVERAGE_REPORT}/coverage.out ./... | go-junit-report > ${CIRCLE_TEST_REPORTS}/junit.xml
-      - run:
-          name: Upload Coverage
-          command: goveralls -coverprofile=${CIRCLE_COVERAGE_REPORT}/coverage.out -service=circle-ci -repotoken=${COVERALLS_TOKEN}
-      - store_test_results:
-          path: /tmp/test-results
-  dockerfile:
-    working_directory: /content-collection-unfolder
-    docker:
-      - image: docker:18
-    steps:
-      - checkout
-      - setup_docker_engine
-      - run:
-          name: Build Dockerfile
-          command: docker build .
+version: 2.1
+
+orbs:
+  ft-golang-ci: financial-times/golang-ci@1
+
 workflows:
-  version: 2
-  test-and-build-docker:
+  tests_and_docker:
     jobs:
-      - build
-      - dockerfile:
+      - ft-golang-ci/build-and-test:
+          name: build-and-test-project
+      - ft-golang-ci/docker-build:
+          name: build-docker-image
           requires:
-            - build
+            - build-and-test-project
+  snyk-scanning:
+    jobs:
+      - ft-golang-ci/scan:
+          name: scan-dependencies
+          context: cm-team-snyk

--- a/common_test.go
+++ b/common_test.go
@@ -8,24 +8,24 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Financial-Times/transactionid-utils-go"
+	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	whitelistedCollection  = "content-package"
-	inputFile              = "content-collection.json"
-	collectionUuid         = "45163790-eec9-11e6-abbc-ee7d9c5b3b90"
-	leadArticleUuid        = "ddda0e1c-a9b2-11e7-8e2d-6debe43a48b4"
-	firstExistingItemUuid  = "aaaac4c6-dcc6-11e6-86ac-f253db7791c6"
-	secondExistingItemUuid = "bbbbc4c6-dcc6-11e6-86ac-f253db7791c6"
-	deletedItemUuid        = "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
-	addedItemUuid          = "d4986a58-de3b-11e6-86ac-f253db7791c6"
-	lastModified           = "2017-01-31T15:33:21.687Z"
+	whitelistedCollection   = "content-package"
+	inputFile               = "content-collection.json"
+	collectionUUID          = "45163790-eec9-11e6-abbc-ee7d9c5b3b90"
+	leadArticleUUID         = "ddda0e1c-a9b2-11e7-8e2d-6debe43a48b4"
+	firstExistingItemUUID   = "aaaac4c6-dcc6-11e6-86ac-f253db7791c6"
+	secondExistingItemUUUID = "bbbbc4c6-dcc6-11e6-86ac-f253db7791c6"
+	deletedItemUUID         = "d9b4c4c6-dcc6-11e6-86ac-f253db7791c6"
+	addedItemUUUID          = "d4986a58-de3b-11e6-86ac-f253db7791c6"
+	lastModified            = "2017-01-31T15:33:21.687Z"
 )
 
-func buildRequest(t *testing.T, serverUrl string, collection string, uuid string, body []byte, tid string) *http.Request {
-	req, err := http.NewRequest(http.MethodPut, serverUrl+buildPath(t, collection, uuid), bytes.NewBuffer(body))
+func buildRequest(t *testing.T, serverURL string, collection string, uuid string, body []byte, tid string) *http.Request {
+	req, err := http.NewRequest(http.MethodPut, serverURL+buildPath(t, collection, uuid), bytes.NewBuffer(body))
 	assert.NoError(t, err)
 
 	req.Header.Add(transactionidutils.TransactionIDHeader, tid)
@@ -37,10 +37,10 @@ func buildPath(t *testing.T, collectionType string, uuid string) string {
 	pathWithCollection := strings.Replace(unfolderPath, "{collectionType}", collectionType, 1)
 	assert.NotEqual(t, unfolderPath, pathWithCollection)
 
-	pathWithCollectionAndUuid := strings.Replace(pathWithCollection, "{uuid}", uuid, 1)
-	assert.NotEqual(t, pathWithCollection, pathWithCollectionAndUuid)
+	pathWithCollectionAndUUID := strings.Replace(pathWithCollection, "{uuid}", uuid, 1)
+	assert.NotEqual(t, pathWithCollection, pathWithCollectionAndUUID)
 
-	return pathWithCollectionAndUuid
+	return pathWithCollectionAndUUID
 }
 
 func readTestFile(t *testing.T, fileName string) []byte {

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -113,8 +113,8 @@ func (service *healthService) producerChecker() (string, error) {
 	return service.config.producer.ConnectivityCheck()
 }
 
-func (service *healthService) httpAvailabilityChecker(healthUri string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, healthUri, nil)
+func (service *healthService) httpAvailabilityChecker(healthURI string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, healthURI, nil)
 	if err != nil {
 		msg := fmt.Sprintf("Error while creating http health check request: %v", err)
 		return msg, errors.New(msg)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	res "github.com/Financial-Times/content-collection-unfolder/resolver"
 	logger "github.com/Financial-Times/go-logger"
 	"github.com/Financial-Times/message-queue-go-producer/producer"
-	"github.com/jawher/mow.cli"
+	cli "github.com/jawher/mow.cli"
 )
 
 const (
@@ -30,7 +30,7 @@ func main() {
 	app.Action = func() {
 		logger.Infof("[Startup] content-collection-unfolder is starting with service config %v", sc.toMap())
 
-		client := setupHttpClient()
+		client := setupHTTPClient()
 		producer := setupMessageProducer(sc, client)
 
 		unfolder := newUnfolder(
@@ -63,7 +63,7 @@ func main() {
 	}
 }
 
-func setupHttpClient() *http.Client {
+func setupHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,

--- a/resolver/uuidResolver_test.go
+++ b/resolver/uuidResolver_test.go
@@ -70,7 +70,7 @@ func TestInvalidLastModified(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestInvalidUuid(t *testing.T) {
+func TestInvalidUUID(t *testing.T) {
 	ccBytes := readTestFile(t, "content-collection-invalid-uuid.json")
 
 	r := NewUuidResolver()

--- a/unfolder_test.go
+++ b/unfolder_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Financial-Times/content-collection-unfolder/forwarder"
 	"github.com/Financial-Times/content-collection-unfolder/relations"
 	"github.com/Financial-Times/content-collection-unfolder/resolver"
-	"github.com/Financial-Times/transactionid-utils-go"
+	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
 	"github.com/Workiva/go-datastructures/set"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -20,19 +20,19 @@ import (
 
 const (
 	ignoredCollection = "story-package"
-	invalidUuid       = "1234"
-	errorJson         = "{\"msg\":\"error\"}"
+	invalidUUID       = "1234"
+	errorJSON         = "{\"msg\":\"error\"}"
 	requestTimeout    = time.Second * 2
 )
 
-func TestInvalidUuid(t *testing.T) {
+func TestInvalidUUID(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	server := startTestServer(u)
 	defer server.Close()
 
 	tid := transactionidutils.NewTransactionID()
-	req := buildRequest(t, server.URL, whitelistedCollection, invalidUuid, readTestFile(t, inputFile), tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, invalidUUID, readTestFile(t, inputFile), tid)
 
 	resp, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
@@ -55,7 +55,7 @@ func TestUuidResolverError(t *testing.T) {
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).
 		Return(resolver.UuidsAndDate{}, errors.New("uuid resolver error"))
@@ -78,7 +78,7 @@ func TestRelationsResolverError(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 
@@ -87,11 +87,11 @@ func TestRelationsResolverError(t *testing.T) {
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&relations.CCRelations{}, errors.New("relations resolver error"))
 
@@ -112,27 +112,27 @@ func TestForwarderError(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{
-		ContainedIn: leadArticleUuid,
-		Contains:    []string{firstExistingItemUuid, secondExistingItemUuid, deletedItemUuid},
+		ContainedIn: leadArticleUUID,
+		Contains:    []string{firstExistingItemUUID, secondExistingItemUUUID, deletedItemUUID},
 	}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 
 	server := startTestServer(u)
 	defer server.Close()
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -141,7 +141,7 @@ func TestForwarderError(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{}, errors.New("forwarder error"))
@@ -161,37 +161,37 @@ func TestForwarderNon200Response(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{
-		ContainedIn: leadArticleUuid,
-		Contains:    []string{firstExistingItemUuid, secondExistingItemUuid, deletedItemUuid},
+		ContainedIn: leadArticleUUID,
+		Contains:    []string{firstExistingItemUUID, secondExistingItemUUUID, deletedItemUUID},
 	}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 
 	server := startTestServer(u)
 	defer server.Close()
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
 		mock.MatchedBy(expectStringSlice(t, uuidsAndDate.UuidArr)),
 		mock.MatchedBy(expectStringSlice(t, oldRelations.Contains))).
 		Return(diffUuidsSet)
-	fwResp := forwarder.ForwarderResponse{Status: http.StatusUnprocessableEntity, ResponseBody: []byte(errorJson)}
+	fwResp := forwarder.ForwarderResponse{Status: http.StatusUnprocessableEntity, ResponseBody: []byte(errorJSON)}
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(fwResp, nil)
@@ -215,27 +215,27 @@ func TestNotWhitelistedCollectionType(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{
-		ContainedIn: leadArticleUuid,
-		Contains:    []string{firstExistingItemUuid, secondExistingItemUuid, deletedItemUuid},
+		ContainedIn: leadArticleUUID,
+		Contains:    []string{firstExistingItemUUID, secondExistingItemUUUID, deletedItemUUID},
 	}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 
 	server := startTestServer(u)
 	defer server.Close()
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, ignoredCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, ignoredCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -244,7 +244,7 @@ func TestNotWhitelistedCollectionType(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, ignoredCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{http.StatusOK, []byte{}}, nil)
@@ -270,27 +270,27 @@ func TestContentResolverError(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{
-		ContainedIn: leadArticleUuid,
-		Contains:    []string{firstExistingItemUuid, secondExistingItemUuid, deletedItemUuid},
+		ContainedIn: leadArticleUUID,
+		Contains:    []string{firstExistingItemUUID, secondExistingItemUUUID, deletedItemUUID},
 	}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 
 	server := startTestServer(u)
 	defer server.Close()
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -299,7 +299,7 @@ func TestContentResolverError(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{http.StatusOK, []byte{}}, nil)
@@ -324,21 +324,21 @@ func TestAllOk(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{
-		ContainedIn: leadArticleUuid,
-		Contains:    []string{firstExistingItemUuid, secondExistingItemUuid, deletedItemUuid},
+		ContainedIn: leadArticleUUID,
+		Contains:    []string{firstExistingItemUUID, secondExistingItemUUUID, deletedItemUUID},
 	}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 
 	contentArr := []map[string]interface{}{
-		{addedItemUuid: addedItemUuid},
-		{deletedItemUuid: deletedItemUuid},
-		{leadArticleUuid: leadArticleUuid},
+		{addedItemUUUID: addedItemUUUID},
+		{deletedItemUUID: deletedItemUUID},
+		{leadArticleUUID: leadArticleUUID},
 	}
 
 	server := startTestServer(u)
@@ -346,11 +346,11 @@ func TestAllOk(t *testing.T) {
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -359,7 +359,7 @@ func TestAllOk(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{http.StatusOK, []byte{}}, nil)
@@ -386,18 +386,18 @@ func TestAllOk_NoLeadArticleRelation(t *testing.T) {
 	mur, mrr, mcd, mf, mcr, mcp, u := newUnfolderWithMocks()
 
 	uuidsAndDate := resolver.UuidsAndDate{
-		UuidArr:      []string{firstExistingItemUuid, secondExistingItemUuid, addedItemUuid},
+		UuidArr:      []string{firstExistingItemUUID, secondExistingItemUUUID, addedItemUUUID},
 		LastModified: lastModified,
 	}
 	oldRelations := relations.CCRelations{}
 	diffUuidsSet := set.New()
-	diffUuidsSet.Add(firstExistingItemUuid)
-	diffUuidsSet.Add(addedItemUuid)
-	diffUuidsSet.Add(deletedItemUuid)
+	diffUuidsSet.Add(firstExistingItemUUID)
+	diffUuidsSet.Add(addedItemUUUID)
+	diffUuidsSet.Add(deletedItemUUID)
 	contentArr := []map[string]interface{}{
-		{firstExistingItemUuid: firstExistingItemUuid},
-		{secondExistingItemUuid: secondExistingItemUuid},
-		{addedItemUuid: addedItemUuid},
+		{firstExistingItemUUID: firstExistingItemUUID},
+		{secondExistingItemUUUID: secondExistingItemUUUID},
+		{addedItemUUUID: addedItemUUUID},
 	}
 
 	server := startTestServer(u)
@@ -405,11 +405,11 @@ func TestAllOk_NoLeadArticleRelation(t *testing.T) {
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -418,7 +418,7 @@ func TestAllOk_NoLeadArticleRelation(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{http.StatusOK, []byte{}}, nil)
@@ -427,7 +427,7 @@ func TestAllOk_NoLeadArticleRelation(t *testing.T) {
 			for _, uuid := range actualDiffUuids {
 				assert.True(t, diffUuidsSet.Exists(uuid))
 			}
-			assert.False(t, contains(actualDiffUuids, leadArticleUuid))
+			assert.False(t, contains(actualDiffUuids, leadArticleUUID))
 			return true
 		}),
 		mock.MatchedBy(expectString(t, tid)),
@@ -462,11 +462,11 @@ func TestAllOk_NewEmptyCollection_NoRelations(t *testing.T) {
 
 	tid := transactionidutils.NewTransactionID()
 	body := readTestFile(t, inputFile)
-	req := buildRequest(t, server.URL, whitelistedCollection, collectionUuid, body, tid)
+	req := buildRequest(t, server.URL, whitelistedCollection, collectionUUID, body, tid)
 
 	mur.On("Resolve", mock.MatchedBy(expectByteSlice(t, body))).Return(uuidsAndDate, nil)
 	mrr.On("Resolve",
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, tid))).
 		Return(&oldRelations, nil)
 	mcd.On("SymmetricDifference",
@@ -475,7 +475,7 @@ func TestAllOk_NewEmptyCollection_NoRelations(t *testing.T) {
 		Return(diffUuidsSet)
 	mf.On("Forward",
 		mock.MatchedBy(expectString(t, tid)),
-		mock.MatchedBy(expectString(t, collectionUuid)),
+		mock.MatchedBy(expectString(t, collectionUUID)),
 		mock.MatchedBy(expectString(t, whitelistedCollection)),
 		mock.MatchedBy(expectByteSlice(t, body))).
 		Return(forwarder.ForwarderResponse{http.StatusOK, []byte{}}, nil)
@@ -499,8 +499,8 @@ func TestMarshallingErrorIs500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 }
 
-func newUnfolderWithMocks() (*mockUuidResolver, *mockRelationsResolver, *mockCollectionsDiffer, *mockForwarder, *mockContentResolver, *mockContentProducer, *unfolder) {
-	mur := new(mockUuidResolver)
+func newUnfolderWithMocks() (*mockUUIDResolver, *mockRelationsResolver, *mockCollectionsDiffer, *mockForwarder, *mockContentResolver, *mockContentProducer, *unfolder) {
+	mur := new(mockUUIDResolver)
 	mrr := new(mockRelationsResolver)
 	mcd := new(mockCollectionsDiffer)
 	mf := new(mockForwarder)
@@ -532,11 +532,11 @@ func (mf *mockForwarder) Forward(tid string, uuid string, collectionType string,
 	return args.Get(0).(forwarder.ForwarderResponse), args.Error(1)
 }
 
-type mockUuidResolver struct {
+type mockUUIDResolver struct {
 	mock.Mock
 }
 
-func (mur *mockUuidResolver) Resolve(reqData []byte) (resolver.UuidsAndDate, error) {
+func (mur *mockUUIDResolver) Resolve(reqData []byte) (resolver.UuidsAndDate, error) {
 	args := mur.Called(reqData)
 	return args.Get(0).(resolver.UuidsAndDate), args.Error(1)
 }


### PR DESCRIPTION
# Description

## What

Standard operation for migration to go modules, snyk and orb integration

## Why

Regular part of Ops Cop work for migration of all go services

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
